### PR TITLE
Fix incorrect page date

### DIFF
--- a/_posts/2021/2021-02-20-my-approach-to-software-planning-and-estimation.md
+++ b/_posts/2021/2021-02-20-my-approach-to-software-planning-and-estimation.md
@@ -3,7 +3,7 @@ title: "My approach to software planning and estimation"
 description: A brief description of how I approach project planning and estimation, with some useful articles and resources.
 published: true
 layout: post
-date: 2021-02-29 12:22:00:00 +0700
+date: 2021-02-20 12:22:00:00 +0700
 tags:
 - web development
 - services

--- a/_posts/2021/2021-03-01-my-approach-to-software-planning-and-estimation.md
+++ b/_posts/2021/2021-03-01-my-approach-to-software-planning-and-estimation.md
@@ -1,0 +1,6 @@
+---
+layout: redirected
+sitemap: false
+permalink: /2021/03/01/my-approach-to-software-planning-and-estimation.html/
+redirect_to: /2021/02/20/my-approach-to-software-planning-and-estimation.html/
+---


### PR DESCRIPTION
Page got published using a date that was incorrect AND does it exist. 

Incorrect/non-existent date: 2021-02-29

Resulting page was being rendered for 2021-03-01

Correct date: 2021-02-20

- Add redirect from 2021-03-01 page to 2021-02-20 page 
- Rename original page to use correct date
- Update original page frontmatter to use correct date in frontmatter

