### PR TITLE
Remove newsletter signup from newsletter posts

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -21,11 +21,6 @@ layout: default
 
   <article class="post-content">
     {{ content }}
-
-    {%- if page.newsletter == true -%}
-    {% include newsletter-signup.html %}
-    {%- endif -%}
-
     {% include announce.html %}
     {% include enquiry.html %}
     {% include rss.html %}


### PR DESCRIPTION
The form doesn’t fit well in the page, subscribing should be done  from the substack site.